### PR TITLE
Breadth first search through Dijkstra's algorithm

### DIFF
--- a/OCaml_implem/breadth_first_search/bfs.ml
+++ b/OCaml_implem/breadth_first_search/bfs.ml
@@ -1,0 +1,43 @@
+type priority_couple = int*int
+
+type weighted_graph = (priority_couple list) array
+
+type priority_queue = priority_couple Heap.t
+
+type distance = Infinite | Finite of int
+
+type predecessor = int option
+
+let priority_couple_order_fun couple1 couple2 =
+  let p1,_ = couple1 
+  and p2,_ = couple2 
+  in p1 < p2
+
+let distance_order_fun distance1 distance2 =
+  match distance1,distance2 with 
+  | Infinite,_ -> true
+  | _,Infinite -> false
+  | Finite d1,Finite d2 -> d1 > d2
+
+let dijkstra graph source =
+  let n = Array.length graph in
+  if source >= n then failwith "Source of Dijkstra's Algorithm is not in the graph"
+  else begin
+    let distance_array = Array.make n (Infinite) in 
+    let _ = distance_array.(source) <- Finite 0 in 
+    let prio_queue = Heap.of_array [|(0,source)|] priority_couple_order_fun in
+    let pred = Array.make n (None) in
+    while not(Heap.is_empty prio_queue) do 
+      let (closest_distance,closest) = Heap.extract prio_queue in 
+      List.iter (fun (weight,node) -> 
+          let new_distance = closest_distance + weight in
+          if distance_order_fun distance_array.(node) (Finite new_distance)
+          then begin
+            distance_array.(node) <- Finite new_distance;
+            Heap.insert prio_queue (new_distance,node);
+            pred.(node) <- Some closest;
+          end)
+        graph.(closest)
+    done;
+    (distance_array,pred)
+  end

--- a/OCaml_implem/breadth_first_search/bfs.ml
+++ b/OCaml_implem/breadth_first_search/bfs.ml
@@ -8,10 +8,7 @@ type distance = Infinite | Finite of int
 
 type predecessor = int option
 
-let priority_couple_order_fun couple1 couple2 =
-  let p1,_ = couple1 
-  and p2,_ = couple2 
-  in p1 < p2
+let priority_couple_order_fun (p1, _) (p2, _) = p1 < p2
 
 let distance_order_fun distance1 distance2 =
   match distance1,distance2 with 

--- a/OCaml_implem/breadth_first_search/bfs.ml
+++ b/OCaml_implem/breadth_first_search/bfs.ml
@@ -21,6 +21,7 @@ let distance_order_fun distance1 distance2 =
 
 let dijkstra graph source =
   let n = Array.length graph in
+  let visited = Array.make n false in
   if source >= n then failwith "Source of Dijkstra's Algorithm is not in the graph"
   else begin
     let distance_array = Array.make n (Infinite) in 
@@ -29,15 +30,18 @@ let dijkstra graph source =
     let pred = Array.make n (None) in
     while not(Heap.is_empty prio_queue) do 
       let (closest_distance,closest) = Heap.extract prio_queue in 
-      List.iter (fun (weight,node) -> 
-          let new_distance = closest_distance + weight in
-          if distance_order_fun distance_array.(node) (Finite new_distance)
-          then begin
-            distance_array.(node) <- Finite new_distance;
-            Heap.insert prio_queue (new_distance,node);
-            pred.(node) <- Some closest;
-          end)
-        graph.(closest)
+      if not(visited.(closest)) then begin
+        List.iter (fun (weight,node) -> 
+            let new_distance = closest_distance + weight in
+            if distance_order_fun distance_array.(node) (Finite new_distance)
+            then begin
+              distance_array.(node) <- Finite new_distance;
+              Heap.insert prio_queue (new_distance,node);
+              pred.(node) <- Some closest;
+            end)
+          graph.(closest);
+        visited.(closest) <- true
+      end
     done;
     (distance_array,pred)
   end

--- a/OCaml_implem/heap/heap.ml
+++ b/OCaml_implem/heap/heap.ml
@@ -3,6 +3,7 @@ open Resizable_array
 type 'a t = {
   mutable size : int;
   values : 'a Resizable_array.t;
+  order_fun : 'a -> 'a -> bool;
 }
 
 (* Get the parent of a given index *)
@@ -18,7 +19,7 @@ let sonr i = 2*i + 2
    assuming that subtrees *)
 let rec heapify h i : unit =
   let imax = List.fold_left (fun acc j ->
-      if get h.values j >= get h.values acc
+      if h.order_fun (get h.values j) (get h.values acc)
       then j else acc
     ) i ([sonl i; sonr i] |> List.filter ((>) (h.size)))
   in
@@ -27,11 +28,10 @@ let rec heapify h i : unit =
     heapify h imax
   end
 
-
-let of_array a =
+let of_array a f =
   let ra = Resizable_array.of_array a in
   let l = Resizable_array.length ra in
-  let h = {size = l; values = ra} in
+  let h = {size = l; values = ra; order_fun = f} in
   for i = (l/2) - 1 downto 0 do
     heapify h i
   done;
@@ -41,7 +41,7 @@ let sift_up h i =
   let p = ref (parent i) in
   let c = ref i in
   let v = get h.values i in
-  while (!c > 0 && get h.values !p <= v) do
+  while (!c > 0 && h.order_fun v (get h.values !p)) do
     swap h.values !p !c;
     p := parent !p;
     c := parent !c;

--- a/OCaml_implem/heap/heap.ml
+++ b/OCaml_implem/heap/heap.ml
@@ -52,6 +52,16 @@ let insert h v =
   sift_up h h.size;
   h.size <- h.size + 1
 
+let extract h =
+  if h.size = 0 then failwith "Heap is of size 0 : cannot extract root"
+  else begin
+    let root = get h.values 0 in
+    swap h.values 0 (h.size -1);
+    h.size <- h.size -1;
+    heapify h 0;
+    root
+  end
+
 let to_array h =
   Array.init h.size (get h.values)
 

--- a/OCaml_implem/heap/heap.ml
+++ b/OCaml_implem/heap/heap.ml
@@ -65,6 +65,9 @@ let extract h =
 let to_array h =
   Array.init h.size (get h.values)
 
+let is_empty h =
+  h.size = 0
+
 let dump h =
   let arr = to_array h in
   Printf.printf "digraph {\n";

--- a/OCaml_implem/heap/heap.mli
+++ b/OCaml_implem/heap/heap.mli
@@ -4,7 +4,7 @@
 type 'a t
 
 (** Array to binary heap conversion *)
-val of_array : 'a array -> 'a t
+val of_array : 'a array -> ('a -> 'a -> bool) -> 'a t
 
 (** Binary heap to array conversion *)
 val to_array : 'a t -> 'a array

--- a/OCaml_implem/heap/heap.mli
+++ b/OCaml_implem/heap/heap.mli
@@ -12,5 +12,8 @@ val to_array : 'a t -> 'a array
 (** Insert a value *)
 val insert : 'a t -> 'a -> unit
 
+(** Extract the root value *)
+val extract : 'a t -> 'a
+
 (** Dump a binary heap in stdout (in dot format) *)
 val dump : int t -> unit

--- a/OCaml_implem/heap/heap.mli
+++ b/OCaml_implem/heap/heap.mli
@@ -15,5 +15,8 @@ val insert : 'a t -> 'a -> unit
 (** Extract the root value *)
 val extract : 'a t -> 'a
 
+(** Returns true if the heap is empty *)
+val is_empty : 'a t -> bool
+
 (** Dump a binary heap in stdout (in dot format) *)
 val dump : int t -> unit

--- a/OCaml_implem/test.ml
+++ b/OCaml_implem/test.ml
@@ -16,7 +16,7 @@ let _ =
   Printf.printf "Min (2) := %d\n" m2;
   Printf.printf "Min (3) := %d\n" m3
 
-let h = Heap.of_array [| 1; 2; 3 |]
+let h = Heap.of_array [| 1; 2; 3 |] (>)
 
 let _ =
   Heap.(

--- a/OCaml_implem/test.ml
+++ b/OCaml_implem/test.ml
@@ -16,6 +16,30 @@ let _ =
   Printf.printf "Min (2) := %d\n" m2;
   Printf.printf "Min (3) := %d\n" m3
 
+let g2 = 
+  [|[(4,1);(2,2)];
+    [(2,3);(3,4);(3,2)];
+    [(1,1);(4,3);(5,4)];
+    [];
+    [(1,3)];
+    []|]
+
+let _ = 
+  let distance_array,pred = Bfs.dijkstra g2 0 in 
+  assert (distance_array.(0) = Finite 0);
+  assert (distance_array.(1) = Finite 3);
+  assert (distance_array.(2) = Finite 2);
+  assert (distance_array.(3) = Finite 5);
+  assert (distance_array.(4) = Finite 6);
+  assert (distance_array.(5) = Infinite);
+  assert (pred.(0) = None);
+  assert (pred.(1) = Some 2);
+  assert (pred.(2) = Some 0);
+  assert (pred.(3) = Some 1);
+  assert (pred.(4) = Some 1);
+  assert (pred.(5) = None);
+  Printf.printf "Dijkstra's algorithm on g2 is correct\n"
+
 let h = Heap.of_array [| 1; 2; 3 |] (>)
 
 let _ =


### PR DESCRIPTION
### Changed the Heap module
- Added an extract function to extract the root of the heap
- Heaps are now generic : the order function is part of the heap structure

### Implemented Dijkstra's algorithm
- **The algorithm uses a priority queue implemented using the heap module**
Nodes are not removed from the priority queue when their priority is updated. Instead the node is inserted again in the queue with its new priority. This way, there is no need to search through the queue to know if the node should be updated or just inserted. I thus added a visited array in order to not visit a node multiple times.
- Added a test


